### PR TITLE
Enter insert mode with `i`

### DIFF
--- a/plugin/vim-minisnip.vim
+++ b/plugin/vim-minisnip.vim
@@ -91,7 +91,7 @@ function! s:SelectPlaceholder()
     if empty(@s)
         " the placeholder was empty, so just enter insert mode directly
         normal! gvd
-        call feedkeys('a', 'n')
+        call feedkeys('i', 'n')
     else
         " paste the placeholder's default value in and enter select mode on it
         execute "normal! gv\"spgv\<C-g>"


### PR DESCRIPTION
This fixes the case where the expansion of a snippet like `[{{++}}]`
results in the cursor being placed after the closing bracket.

I don't really know if it does break any other case.