### PR TITLE
Indent the body of the snippet

### DIFF
--- a/plugin/vim-minisnip.vim
+++ b/plugin/vim-minisnip.vim
@@ -69,11 +69,15 @@ function! s:SelectPlaceholder()
     " we also use keeppatterns to avoid clobbering the search history /
     "   highlighting all the other placeholders
     try
+        " gn misbehaves when 'wrapscan' isn't set (see vim's #1683)
+        let [l:ws, &ws] = [&ws, 1]
         silent keeppatterns execute 'normal! /' . s:delimpat . "/e\<cr>gn\"sy"
     catch /E486:/
         " There's no placeholder at all, enter insert mode
         call feedkeys('i', 'n')
         return
+    finally
+        let &ws = l:ws
     endtry
 
     " save the contents of the previous placeholder (for backrefs)


### PR DESCRIPTION
Inspired by #9 here's an alternative to #8 that tries to do one thing well: indenting the snippet.
The main reason behind this PR is that I sometimes disagree with the built-in indentation engine
and I just want vim to slap that damn snippet where my cursor is, nothing more and nothing less.