### PR TITLE
Use \f instead of \w

### DIFF
--- a/plugin/vim-minisnip.vim
+++ b/plugin/vim-minisnip.vim
@@ -11,7 +11,7 @@ let s:delimpat = '\V' . g:minisnip_startdelim . '\.\{-}' . g:minisnip_enddelim
 
 function! <SID>ShouldTrigger()
     silent! unlet! s:snippetfile
-    let l:cword = matchstr(getline('.'), '\v\w+%' . col('.') . 'c')
+    let l:cword = matchstr(getline('.'), '\v\f+%' . col('.') . 'c')
 
     " look for a snippet by that name
     let l:snippetfile = g:minisnip_dir . '/' . l:cword


### PR DESCRIPTION
We're interested in whatever word under the cursor is also a valid
filename.

Fixes #15 
Ping @joereynolds, you may want to merge this into your own fork too